### PR TITLE
Added ApplicableRefT for passing stages by reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build/
 out/
 .cache/
 compile_commands.json
+.vscode/

--- a/include/mr-contractor/apply.hpp
+++ b/include/mr-contractor/apply.hpp
@@ -161,7 +161,7 @@ namespace mr {
     }
 
   template <StageT S>
-    typename S::TaskT apply(const S &stage, typename S::InputT &&initial) {
+    typename S::TaskT apply(const S &stage, typename S::InputT initial) {
       using TaskImplT = S::TaskImplT;
       using TaskT = S::TaskT;
 

--- a/include/mr-contractor/stages.hpp
+++ b/include/mr-contractor/stages.hpp
@@ -124,7 +124,7 @@ namespace mr {
     };
 
   template <StageT S> typename S::TaskT apply(const S &stage, FunctionWrapper<typename S::InputT(void)> &&getter);
-  template <StageT S> typename S::TaskT apply(const S &stage, typename S::InputT &&initial);
+  template <StageT S> typename S::TaskT apply(const S &stage, typename S::InputT initial);
 }
 
 namespace mr::detail {

--- a/include/mr-contractor/stages.hpp
+++ b/include/mr-contractor/stages.hpp
@@ -40,7 +40,25 @@ namespace mr {
   template <typename ...Us> constexpr bool is_parallel<Parallel<Us...>> = true;
   template <typename T> concept ParallelT = is_parallel<T>;
 
-  template <typename T> concept StageT = Callable<T> || ParallelT<T> || SequenceT<T>;
+  template <typename T> concept ApplicableT = ParallelT<T> || SequenceT<T>;
+
+  template <typename T> constexpr bool is_stage_reference = false;
+  template <ApplicableT T> constexpr bool is_stage_reference<std::reference_wrapper<T>> = true;
+  template <typename T> concept ApplicableRefT = is_stage_reference<T>;
+
+  template <typename T> concept StageT = Callable<T> || ApplicableT<T> || ApplicableRefT<T>;
+
+  namespace detail {
+    template <ApplicableT T>
+      struct to_wrapper<T> {
+        using type = FunctionWrapper<typename T::OutputT(typename T::InputT)>;
+      };
+
+    template <ApplicableT T>
+      struct to_wrapper<std::reference_wrapper<T>> {
+        using type = typename to_wrapper<T>::type;
+      };
+  }
 
   template <StageT ...StageTs> requires (sizeof...(StageTs) > 0)
     struct Parallel<StageTs...> {
@@ -99,18 +117,17 @@ namespace mr {
   template <typename ...StageTs>
     Sequence(StageTs... stages) -> Sequence<StageTs...>;
 
-  template <typename T> concept ApplicableT = ParallelT<T> || SequenceT<T>;
+  template <StageT Stage>
+    struct CallableTraits<std::reference_wrapper<Stage>> {
+      using InputT = input_t<Stage>;
+      using OutputT = output_t<Stage>;
+    };
 
   template <StageT S> typename S::TaskT apply(const S &stage, FunctionWrapper<typename S::InputT(void)> &&getter);
   template <StageT S> typename S::TaskT apply(const S &stage, typename S::InputT &&initial);
 }
 
 namespace mr::detail {
-  template <ApplicableT T>
-    struct to_wrapper<T> {
-      using type = FunctionWrapper<typename T::OutputT(typename T::InputT)>;
-    };
-
   template <typename T>
     to_wrapper_t<T> to_wrapper_v(T&& stage) {
       if constexpr (Callable<T>) {
@@ -125,6 +142,19 @@ namespace mr::detail {
         return FunctionWrapper<OutputT(InputT)>(
           [inner_stage=std::forward<T>(stage)](InputT input) mutable {
             auto task = mr::apply(inner_stage, std::move(input));
+            task->execute();
+            return task->result();
+          }
+        );
+      } else if constexpr (ApplicableRefT<T>) {
+        using RealStageT = typename T::type;
+
+        using InputT = input_t<RealStageT>;
+        using OutputT = output_t<RealStageT>;
+
+        return FunctionWrapper<OutputT(InputT)>(
+          [stage_ref = stage](InputT input) mutable {
+            auto task = mr::apply(stage_ref.get(), std::move(input));
             task->execute();
             return task->result();
           }

--- a/include/mr-contractor/task.hpp
+++ b/include/mr-contractor/task.hpp
@@ -46,7 +46,7 @@ namespace mr::detail {
       SeqTaskImpl() = default;
       ~SeqTaskImpl() override = default;
 
-      SeqTaskImpl(InputT &&initial)
+      SeqTaskImpl(InputT initial)
         : _initial(std::move(initial))
       {}
 
@@ -135,8 +135,8 @@ namespace mr::detail {
       ParTaskImpl(ParTaskImpl &&) = default;
       ParTaskImpl & operator=(ParTaskImpl &&) = default;
 
-      ParTaskImpl(InputT &&initial)
-        : _initial(initial)
+      ParTaskImpl(InputT initial)
+        : _initial(std::move(initial))
       {}
 
       ParTaskImpl(FunctionWrapper<InputT(void)> getter)

--- a/include/mr-contractor/traits.hpp
+++ b/include/mr-contractor/traits.hpp
@@ -46,16 +46,16 @@ namespace mr {
 
   template<typename R, typename C, typename A>
     struct CallableMemberTraits<R (C::*)(A) const> : details::InputTOutputT<A, R> {};
-  
+
   template<typename R, typename C, typename A>
     struct CallableMemberTraits<R (C::*)(A) &> : details::InputTOutputT<A, R> {};
-  
+
   template<typename R, typename C, typename A>
     struct CallableMemberTraits<R (C::*)(A) const &> : details::InputTOutputT<A, R> {};
-  
+
   template<typename R, typename C, typename A>
     struct CallableMemberTraits<R (C::*)(A) &&> : details::InputTOutputT<A, R> {};
-  
+
   template<typename R, typename C, typename A>
     struct CallableMemberTraits<R (C::*)(A) const &&> : details::InputTOutputT<A, R> {};
 


### PR DESCRIPTION
Now for passing stage by reference we can use `std::ref`. See test: we can not pass simple `seq1`, we must explicit write `std::ref(seq1)` for passing by reference or `std::move(seq1)` to transfer ownership

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for reference-wrapped stages in sequence and parallel task compositions.
- **Bug Fixes**
  - Enhanced type handling and compatibility for reference-wrapped stages during task execution.
- **Tests**
  - Added test cases validating sequences and parallels composed with reference-wrapped stages.
- **Chores**
  - Updated `.gitignore` to exclude Visual Studio Code workspace settings.
  - Improved constructor parameter passing for task implementations to better manage input values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->