### PR TITLE
Change concept naming & refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 *.out
 *.app
 
+.vs/
 build/
 out/
 .cache/

--- a/include/mr-contractor/def.hpp
+++ b/include/mr-contractor/def.hpp
@@ -21,6 +21,18 @@ namespace mr {
   template <typename ...Ts>
     using to_tuple_t = std::tuple<Ts...>;
 
+  template<template<typename...> typename TemplateT, typename InstanceT>
+    constexpr bool is_instance_of = false;
+
+  template<template<typename...> typename TemplateT, typename... Ts>
+    constexpr bool is_instance_of<TemplateT, TemplateT<Ts...>> = true;
+
+  // works only for templates without NTTP
+  // note: seems there's no way to pass any arbitrary templated type as `TemplateT`, because
+  //       type, non-type and template template parameters can't be generalized by `typename...` nor `auto...`
+  template<typename InstanceT, template<typename...> typename TemplateT>
+    concept InstanceOf = is_instance_of<TemplateT, InstanceT>;
+
   template <typename ...Ts>
     constexpr mp::vector<mp::info> unique_v(std::ranges::range auto &&ts) {
       mp::vector<mp::info> res;

--- a/include/mr-contractor/traits.hpp
+++ b/include/mr-contractor/traits.hpp
@@ -91,16 +91,17 @@ namespace mr {
         using OutputT = typename Impl::OutputT;
     };
 
-  template <typename F> using input_t = CallableTraits<std::remove_cvref_t<F>>::InputT;
-  template <typename F> using output_t = CallableTraits<std::remove_cvref_t<F>>::OutputT;
+  template <typename FuncT> using input_t = CallableTraits<std::remove_cvref_t<FuncT>>::InputT;
+  template <typename FuncT> using output_t = CallableTraits<std::remove_cvref_t<FuncT>>::OutputT;
+  template <typename FuncT> using func_t = output_t<FuncT>(input_t<FuncT>);
 
-  // Concept to check if T is a valid callable with one argument
-  template<typename T>
+  // Concept to check if FuncT is a valid callable with one argument
+  template<typename FuncT>
     concept Callable = requires {
-      // Ensure CallableTraits<T> provides InputT and OutputT
-      typename input_t<T>;
-      typename output_t<T>;
-      // Ensure T can be called with InputT and returns OutputT
-      requires std::is_invocable_r_v<output_t<T>, T, input_t<T>>;
+      // Ensure CallableTraits provides InputT and OutputT
+      typename input_t<FuncT>;
+      typename output_t<FuncT>;
+      // Ensure FuncT can be called with InputT and returns OutputT
+      requires std::is_invocable_r_v<output_t<FuncT>, FuncT, input_t<FuncT>>;
     };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized and unified template parameter naming and concept names for improved clarity and consistency.
  - Introduced a new mechanism to detect template instantiations and added a concept for constraining types based on template instantiation.
  - Updated type aliases and concepts for more descriptive and consistent usage.
  - Adjusted task implementation templates to use type-based size parameters and refined result return types.
  - Simplified and modernized template metaprogramming patterns for stage and task composition.

- **Chores**
  - Updated `.gitignore` to exclude Visual Studio workspace settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->